### PR TITLE
feat: adding slippage

### DIFF
--- a/env.schema.ts
+++ b/env.schema.ts
@@ -13,6 +13,7 @@ export const EnvSchema = Type.Object({
   REACT_APP_GITBOOK_URL: Type.String({ format: "uri" }),
   REACT_APP_INDEXER_URL: Type.String({ format: "uri" }),
   REACT_APP_MULTICALL_ADDRESS: Type.Optional(TypeEthAddress()),
+  REACT_APP_PAYMENT_SLIPPAGE_PERCENT: Type.Integer({ minimum: 0, maximum: 100, default: 1 }),
   REACT_APP_READ_ONLY_ETH_NODE_URL: Type.String({ format: "uri" }),
   REACT_APP_TITAN_LIGHTNING_POOL: Type.String({ default: "pplp.titan.io:4141" }),
   REACT_APP_URL: Type.String({ format: "uri" }),

--- a/src/components/Forms/BuyForm.tsx
+++ b/src/components/Forms/BuyForm.tsx
@@ -13,7 +13,11 @@ import { TransactionForm } from "./Shared/MultistepForm";
 import { CreateEditPurchaseForm } from "./Shared/CreateEditPurchaseForm";
 import type { TransactionReceipt } from "viem/_types/types/transaction";
 import type { GetResponse } from "../../gateway/interfaces";
-import { getLastPurchaseDestination, setPoolInfo, storeLastPurchaseDestination } from "../../gateway/localStorage";
+import {
+  getLastPurchaseDestination,
+  setPoolInfo,
+  storeLastPurchaseDestination,
+} from "../../gateway/localStorage";
 import { useQueryClient } from "@tanstack/react-query";
 import { GenericConfirmContent } from "./Shared/GenericConfirmContent";
 import { GenericCompletedContent } from "./Shared/GenericCompletedContent";
@@ -24,7 +28,11 @@ import { useApproveFee } from "../../hooks/data/useApproveFee";
 import { implementationAbi } from "contracts-js/dist/abi/abi";
 import { formatFeePrice, formatHashrateTHPS, formatPaymentPrice } from "../../lib/units";
 import { formatDuration } from "../../lib/duration";
-import { getPredefinedPoolByAddress, getPredefinedPoolByIndex, predefinedPools } from "./BuyerForms/predefinedPools";
+import {
+  getPredefinedPoolByAddress,
+  getPredefinedPoolByIndex,
+  predefinedPools,
+} from "./BuyerForms/predefinedPools";
 
 interface BuyFormProps {
   contractId: string;
@@ -42,6 +50,11 @@ export const BuyForm: FC<BuyFormProps> = memo(
 
     const { data: validators } = useValidators({ offset: 0, limit: 100 });
     const contract = useContractV2({ address: contractId as `0x${string}` });
+
+    const slippagePercent = process.env.REACT_APP_PAYMENT_SLIPPAGE_PERCENT;
+    const priceWSlippage =
+      (BigInt(contract.data!.price) * BigInt(100 + slippagePercent)) / BigInt(100);
+    const feeWSlippage = (BigInt(contract.data!.fee) * BigInt(100 + slippagePercent)) / BigInt(100);
 
     const lastPurchaseDestination = getLastPurchaseDestination();
     const lastPool = getPredefinedPoolByAddress(lastPurchaseDestination?.poolAddress);
@@ -72,7 +85,7 @@ export const BuyForm: FC<BuyFormProps> = memo(
           key="form"
         />
       ),
-      [form.control, form.resetField, form.setValue],
+      [form.control, form.resetField, form.setValue]
     );
 
     return (
@@ -104,7 +117,7 @@ export const BuyForm: FC<BuyFormProps> = memo(
                 Duration: formatDuration(BigInt(contract.data!.length)),
                 "Price / Fee": `${formatPaymentPrice(contract.data!.price).full} / ${
                   formatFeePrice(contract.data!.fee).full
-                }`,
+                } ± ${slippagePercent}% slippage`,
                 ...(isCustomValidator
                   ? {
                       "Custom Validator Host": customValidatorHost,
@@ -135,7 +148,10 @@ export const BuyForm: FC<BuyFormProps> = memo(
                   You will be receiving hashpower shortly.
                   {isLightning && (
                     <a
-                      href={process.env.REACT_APP_TITAN_LIGHTNING_DASHBOARD || "https://lightning.titan.io"}
+                      href={
+                        process.env.REACT_APP_TITAN_LIGHTNING_DASHBOARD ||
+                        "https://lightning.titan.io"
+                      }
                       target="_blank"
                       rel="noreferrer"
                       style={{ cursor: "pointer" }}
@@ -156,7 +172,7 @@ export const BuyForm: FC<BuyFormProps> = memo(
               try {
                 const receipt = await payment.approveAsync({
                   spender: process.env.REACT_APP_CLONE_FACTORY,
-                  amount: BigInt(contract.data!.price),
+                  amount: priceWSlippage,
                 });
                 return receipt ? { txhash: receipt, isSkipped: false } : { isSkipped: true };
               } catch (error) {
@@ -170,7 +186,7 @@ export const BuyForm: FC<BuyFormProps> = memo(
             action: async () => {
               const receipt = await fee.approveAsync({
                 spender: process.env.REACT_APP_CLONE_FACTORY,
-                amount: BigInt(contract.data!.fee),
+                amount: feeWSlippage,
               });
               return receipt ? { txhash: receipt, isSkipped: false } : { isSkipped: true };
             },
@@ -198,7 +214,10 @@ export const BuyForm: FC<BuyFormProps> = memo(
                 validatorHost = data.customValidatorHost;
               } else {
                 const validator = validators?.find((v) => v.addr === data.validatorAddress)!;
-                validatorPublicKey = decompressPublicKey(validator.pubKeyYparity, validator.pubKeyX);
+                validatorPublicKey = decompressPublicKey(
+                  validator.pubKeyYparity,
+                  validator.pubKeyX
+                );
                 validatorAddr = publicKeyToAddress(validatorPublicKey);
                 validatorHost = validator.host;
               }
@@ -232,7 +251,9 @@ export const BuyForm: FC<BuyFormProps> = memo(
               await waitForBlockNumber(receipt.blockNumber, qc);
               const startTime = qc
                 .getQueryData<GetResponse<HashRentalContract[]>>([CONTRACTS_QK])
-                ?.data.find((c) => isAddressEqual(c.id as `0x${string}`, contractId as `0x${string}`))?.timestamp;
+                ?.data.find((c) =>
+                  isAddressEqual(c.id as `0x${string}`, contractId as `0x${string}`)
+                )?.timestamp;
 
               if (!startTime) {
                 throw new Error("Start time not found");
@@ -258,5 +279,5 @@ export const BuyForm: FC<BuyFormProps> = memo(
   },
   (prevProps, nextProps) => {
     return prevProps.contractId === nextProps.contractId;
-  },
+  }
 );

--- a/src/components/Forms/EditSeller.tsx
+++ b/src/components/Forms/EditSeller.tsx
@@ -9,9 +9,9 @@ import InputAdornment from "@mui/material/InputAdornment";
 import TextField from "@mui/material/TextField";
 import { formatFeePrice, sellerStakeToken } from "../../lib/units";
 import { GenericCompletedContent } from "./Shared/GenericCompletedContent";
-import { useApproveFee } from "../../hooks/data/useApproveFee";
 import { cloneFactoryAbi } from "contracts-js/dist/abi/abi";
 import { useFeeTokenBalance } from "../../hooks/data/useFeeTokenBalance";
+import { useApproveStaking } from "../../hooks/data/useApproveStaking";
 
 export interface EditSellerInput {
   stake: string;
@@ -27,7 +27,7 @@ export const EditSellerForm: FC<EditSellerFormProps> = memo(
     const { address: userAccount } = useAccount();
     const pc = usePublicClient();
     const wc = useWalletClient();
-    const fee = useApproveFee();
+    const fee = useApproveStaking();
     const balance = useFeeTokenBalance(userAccount!);
 
     // Input validation setup
@@ -56,7 +56,9 @@ export const EditSellerForm: FC<EditSellerFormProps> = memo(
                 message: "You cannot reduce your stake. Unregister if you want to exit.",
               },
               max: {
-                value: maxStakeValue ? formatFeePrice(maxStakeValue).value : Number.POSITIVE_INFINITY,
+                value: maxStakeValue
+                  ? formatFeePrice(maxStakeValue).value
+                  : Number.POSITIVE_INFINITY,
                 message: `Not enough balance. The maximum stake you can have is ${
                   formatFeePrice(maxStakeValue!).valueRounded
                 } ${sellerStakeToken.symbol}`,
@@ -94,7 +96,9 @@ export const EditSellerForm: FC<EditSellerFormProps> = memo(
             }}
           />
         )}
-        resultForm={(props) => <GenericCompletedContent title="Your seller record has been updated" />}
+        resultForm={(props) => (
+          <GenericCompletedContent title="Your seller record has been updated" />
+        )}
         transactionSteps={[
           {
             label: "Approve the stake",
@@ -137,5 +141,5 @@ export const EditSellerForm: FC<EditSellerFormProps> = memo(
   },
   (prevProps, nextProps) => {
     return prevProps.sellerStake === nextProps.sellerStake;
-  },
+  }
 );

--- a/src/components/Forms/EditValidator.tsx
+++ b/src/components/Forms/EditValidator.tsx
@@ -12,7 +12,7 @@ import { compressPublicKey } from "../../lib/pubkey";
 import { isValidHost } from "../../utils/validators";
 import { GenericCompletedContent } from "./Shared/GenericCompletedContent";
 import { useGetPublicKey } from "../../hooks/data/usePublicKey";
-import { useApproveFee } from "../../hooks/data/useApproveFee";
+import { useApproveStaking } from "../../hooks/data/useApproveStaking";
 
 export interface EditValidatorInput {
   stake: string;
@@ -31,7 +31,7 @@ export const EditValidatorForm: FC<EditValidatorFormProps> = memo((props) => {
   const pc = usePublicClient();
   const wc = useWalletClient();
   const { getPublicKeyAsync } = useGetPublicKey();
-  const fee = useApproveFee();
+  const fee = useApproveStaking();
 
   // Input validation setup
   const form = useForm<EditValidatorInput>({
@@ -118,7 +118,9 @@ export const EditValidatorForm: FC<EditValidatorFormProps> = memo((props) => {
           }}
         />
       )}
-      resultForm={(props) => <GenericCompletedContent title="Your validator record has been updated" />}
+      resultForm={(props) => (
+        <GenericCompletedContent title="Your validator record has been updated" />
+      )}
       transactionSteps={[
         {
           label: "Sign the message so we can retrieve your Public Key",

--- a/src/components/Forms/RegisterSeller.tsx
+++ b/src/components/Forms/RegisterSeller.tsx
@@ -17,6 +17,7 @@ import { useFeeTokenBalance } from "../../hooks/data/useFeeTokenBalance";
 import { useOnMountUnsafe } from "../../hooks/useOnMountUnsafe";
 import { memo, useCallback, useMemo } from "react";
 import { Input } from "@mui/material";
+import { useApproveStaking } from "../../hooks/data/useApproveStaking";
 
 export interface RegisterSellerInput {
   stake: string;
@@ -30,7 +31,7 @@ export const RegisterSellerForm: React.FC<CreateFormProps> = memo(({ onClose }) 
   const publicClient = usePublicClient();
   const wc = useWalletClient();
   const { address } = useAccount();
-  const fee = useApproveFee();
+  const fee = useApproveStaking();
 
   const minSellerStakeQuery = useReadContract({
     address: process.env.REACT_APP_CLONE_FACTORY,
@@ -60,7 +61,9 @@ export const RegisterSellerForm: React.FC<CreateFormProps> = memo(({ onClose }) 
     },
   });
 
-  const minStake = minSellerStakeQuery.isSuccess ? formatFeePrice(minSellerStakeQuery.data) : undefined;
+  const minStake = minSellerStakeQuery.isSuccess
+    ? formatFeePrice(minSellerStakeQuery.data)
+    : undefined;
   const balanceValue = balance?.data ? formatFeePrice(balance.data) : undefined;
 
   const inputForm = () => {
@@ -75,7 +78,9 @@ export const RegisterSellerForm: React.FC<CreateFormProps> = memo(({ onClose }) 
         },
         max: {
           value: balanceValue?.value || Number.POSITIVE_INFINITY,
-          message: `Not enough balance. You have ${balanceValue?.value || 0} ${sellerStakeToken.symbol}`,
+          message: `Not enough balance. You have ${balanceValue?.value || 0} ${
+            sellerStakeToken.symbol
+          }`,
         },
       },
     });

--- a/src/components/Forms/RegisterValidator.tsx
+++ b/src/components/Forms/RegisterValidator.tsx
@@ -13,7 +13,7 @@ import { compressPublicKey } from "../../lib/pubkey";
 import { isValidHost } from "../../utils/validators";
 import { GenericCompletedContent } from "./Shared/GenericCompletedContent";
 import { useGetPublicKey } from "../../hooks/data/usePublicKey";
-import { useApproveFee } from "../../hooks/data/useApproveFee";
+import { useApproveStaking } from "../../hooks/data/useApproveStaking";
 
 export interface RegisterValidatorInput {
   stake: string;
@@ -30,7 +30,7 @@ export const RegisterValidatorForm: React.FC<CreateFormProps> = memo(({ onClose 
   const publicClient = usePublicClient();
   const minStakeRef = useRef<bigint>(0n);
   const { getPublicKeyAsync } = useGetPublicKey();
-  const fee = useApproveFee();
+  const fee = useApproveStaking();
 
   // Input validation setup
   const form = useForm<RegisterValidatorInput>({

--- a/src/hooks/data/useApproveStaking.ts
+++ b/src/hooks/data/useApproveStaking.ts
@@ -1,0 +1,7 @@
+import { useFeeTokenAddress } from "./useFeeTokenBalance";
+import { useApproveERC20 } from "./useApproveERC20";
+
+export function useApproveStaking() {
+  const { data: feeTokenAddress } = useFeeTokenAddress();
+  return useApproveERC20(feeTokenAddress!);
+}


### PR DESCRIPTION
- Adding configurable slippage value, that increases value that we approve before buying to adjust to price volatility. 
Increased approve value does not increase the price of the contract itself.
- Replaced useApproveFee to useApproveStaking where appropriate, it is more meaningful even if it is the same token underneath
